### PR TITLE
[Survey] Fix issue with deadlines in the past.

### DIFF
--- a/survey/survey.py
+++ b/survey/survey.py
@@ -92,7 +92,7 @@ class Survey:
             dl = dl.replace(tzinfo=pytz.utc)
 
         if adjust and (dl - datetime.utcnow().replace(tzinfo=pytz.utc)
-            ).total_seconds() < 0:
+                       ).total_seconds() < 0:
             dl += timedelta(days=1)
 
         return dl


### PR DESCRIPTION
There was a situation where, if you give just a time as a deadline, and that time has already passed today, the deadline will use today and that time, meaning the deadline will be in the past. This causes surveys to auto-close immediately, which is not desired (probably). Fix is to check the initial parsed deadline to see if it is in the past, in which case the day is bumped forward by 1. Thanks to @AbrahamHydra for discovering this.

This commit also makes the printed deadline in the bot DM standardized and easier to read.

Fixes #28.