### PR TITLE
Hide CatFact so it doesn't appear in cogs.red

### DIFF
--- a/catfact/info.json
+++ b/catfact/info.json
@@ -5,5 +5,6 @@
     "SHORT" : "Get random cat facts.",
     "DESCRIPTION" : "Gets the given number of cat facts.",
     "REQUIREMENTS" : [],
-    "TAGS": ["animals", "cat", "random", "fun"]
+    "TAGS": ["animals", "cat", "random", "fun"],
+    "HIDDEN": true
 }


### PR DESCRIPTION
This is the result of API breakage with the API this cog uses

