### PR TITLE
Red 3.1 __unload -> cog_unload

### DIFF
--- a/catfact/catfact.py
+++ b/catfact/catfact.py
@@ -15,7 +15,7 @@ class CatFact(getattr(commands, "Cog", object)):
     self.__url = 'https://catfact.ninja/fact'
     self.__session = aiohttp.ClientSession()
 
-  def __unload(self):
+  def cog_unload(self):
     if self.__session:
       asyncio.get_event_loop().create_task(self.__session.close())
 

--- a/lenny/lenny.py
+++ b/lenny/lenny.py
@@ -37,7 +37,7 @@ class Lenny(getattr(commands, "Cog", object)):
     self.__url = 'http://lenny.today/api/v1/random?limit=1'
     self.__session = aiohttp.ClientSession()
 
-  def __unload(self):
+  def cog_unload(self):
     if self.__session:
       asyncio.get_event_loop().create_task(self.__session.close())
 

--- a/randimals/randimals.py
+++ b/randimals/randimals.py
@@ -18,7 +18,7 @@ class Randimals(getattr(commands, "Cog", object)):
   def __init__(self):
     self.__session = aiohttp.ClientSession()
 
-  def __unload(self):
+  def cog_unload(self):
     if self.__session:
       asyncio.get_event_loop().create_task(self.__session.close())
 


### PR DESCRIPTION
### I am submitting a...
```
 [x] Bug fix
 [ ] Feature addition or improvement for an existing cog
```

### Name of the cog in question:
catfact, randimals, lenny

### Description of my bug fix/improvement:
Change `__unload` to `cog_unload` to work with Red 3.1.x.