### PR TITLE
Checks if there is any streaming active in the background activities …

### DIFF
--- a/streamrole/streamrole.py
+++ b/streamrole/streamrole.py
@@ -191,7 +191,7 @@ class StreamRole(getattr(commands, "Cog", object)):
 
     guild = after.guild
     config = await self.config.guild(guild).all()
-    activity = after.activity
+    is_streaming = any(True for a in after.activities if a.type == discord.ActivityType.streaming)
     if config['enabled'] and config['role'] is not None:
       streaming_role = get(guild.roles, id=config['role'])
 
@@ -203,9 +203,7 @@ class StreamRole(getattr(commands, "Cog", object)):
         return
 
       # is not streaming; attempt to remove streaming role if present
-      if activity is None \
-          or activity.type != discord.ActivityType.streaming \
-          and streaming_role in after.roles:
+      if not is_streaming and streaming_role in after.roles:
         try:
           await after.remove_roles(streaming_role,
                                    reason='Member is not streaming.')
@@ -222,9 +220,7 @@ class StreamRole(getattr(commands, "Cog", object)):
 
       # is streaming; attempt to add streaming role if not present
       # and if allowed by promotion settings
-      elif activity \
-          and activity.type == discord.ActivityType.streaming \
-          and streaming_role not in after.roles:
+      elif is_streaming and streaming_role not in after.roles:
         if self.__can_promote(after, config):
           try:
             await after.add_roles(streaming_role,

--- a/streamrole/streamrole.py
+++ b/streamrole/streamrole.py
@@ -191,7 +191,7 @@ class StreamRole(getattr(commands, "Cog", object)):
 
     guild = after.guild
     config = await self.config.guild(guild).all()
-    is_streaming = any(True for a in after.activities if a.type == discord.ActivityType.streaming)
+    is_streaming = any(a.type == discord.ActivityType.streaming for a in after.activities)
     if config['enabled'] and config['role'] is not None:
       streaming_role = get(guild.roles, id=config['role'])
 


### PR DESCRIPTION
…too instead of just the main activity

### I am submitting a...
```
 [ ] Bug fix
 [x] Feature addition or improvement for an existing cog
```

### Name of the cog in question:
streamrole

### Description of my bug fix/improvement:
Changed it to look into the users background this also addressed a point made in Cog-Creators/Red-DiscordBot#2893

> All streamer role cog stuff I've found so far relies upon the person's profile being detected as streamer mode (which is rather flawed as all they have to do is alt tab to something else like Spotify and the role is removed).

This will now keep/add the streamer role even if streaming is not their top activity (if they went into Spotify after they started streaming etc), I've been using this logic on my fork of Red and it always picks up when a user is streaming correctly
