### PR TITLE
fix welcomeset bug with long whisper messages, and added fallback type

### DIFF
--- a/welcome/enums.py
+++ b/welcome/enums.py
@@ -5,3 +5,4 @@ class WhisperType(Enum):
   OFF = 'off'
   ONLY = 'only'
   BOTH = 'both'
+  FALLBACK = 'fall'


### PR DESCRIPTION
### I am submitting a...
```
 [ ] Bug fix
 [x] Feature addition or improvement for an existing cog
```

### Name of the cog in question:
Welcome

### Description of my bug fix/improvement:
I've added a new welcome join whisper type: Fallback. It tries to send the whisper message to the user in a DM, if it fails (for whatever reason, normally if the user has DM from server members turned off), it will send the whisper message to the channel set for Welcomes.

This is good so that those with that setting turned off they can still get the welcome message, and not miss out on important info.
