### PR TITLE
fix(lenny): protect against discord transforming symbol in emoji

### DIFF
--- a/lenny/lenny.py
+++ b/lenny/lenny.py
@@ -152,6 +152,17 @@ LENNY_PARTS: Dict[str, List[str]] = {
 }
 
 
+def protect_against_emojification(text) -> str:
+    res = ""
+    for symbol in text:
+        if symbol == "\\":
+            res += symbol
+        else:
+            res += symbol + "\N{VARIATION SELECTOR-15}"
+
+    return res
+
+
 class Lenny(commands.Cog):
     """乁(-ロ-)ㄏ"""
 
@@ -180,6 +191,8 @@ class Lenny(commands.Cog):
                 lenny = (await response.json())[0]["face"]
                 # escape markdown characters
                 lenny = discord.utils.escape_markdown(lenny)
+                # protect against discord transforming symbol in emoji
+                lenny = protect_against_emojification(lenny)
         # if the API call fails, make a (more limited) lenny locally instead
         except aiohttp.ClientError:
             log.warning("API call failed; falling back to local lenny")

--- a/nestedcommands/nestedcommands.py
+++ b/nestedcommands/nestedcommands.py
@@ -56,7 +56,8 @@ class NestedCommands(commands.Cog):
                 channel: discord.TextChannel = discord.utils.get(ctx.guild.text_channels, id=channel)
 
             msg = box(
-                f"  Enabled: {enabled}\n  Channel: {channel and channel.name}\n", "Current NestedCommands settings:",
+                f"  Enabled: {enabled}\n  Channel: {channel and channel.name}\n",
+                "Current NestedCommands settings:",
             )
 
             await ctx.send(msg)


### PR DESCRIPTION
#### I am submitting a
- [x] Bug fix
- [ ] Feature addition or improvement for an existing cog

#### Name of the cog(s) in question
lenny


#### Description of my bug fix/improvement
<!-- What do your changes accomplish? -->
Discord (github also does it :angry: ) will automatically change some symbol into emoji `└[□⏏□]┘` goes └[□⏏□]┘ so we need to protect the symbol that will be transformed by adding `\N{VARIATION SELECTOR-15}` behind it, the emoji goes└[□⏏︎□]┘.
If we only added that string behind a symbol that get transformed we would have to do a list of changing symbol but putting it behind every symbol doesn't change them (i'm not sure at 100% that i'm correct on that) so i put it behind every symbol, exeption goes for \\ so we keep character escaped for markdown (and they can't change to emoji, yay)
#### Verification steps
<!-- What did you do to verify that your changes work properly? -->
Through a lot of usage the lenny command i can say that it works (i hope i don't get banned from that api for spamming it/ddosing it /s) and also thanks to that i feel that i see an incorrect pixel on symbols which are exactly the same